### PR TITLE
Update instructions for Windows compile

### DIFF
--- a/haskell/BUILD.md
+++ b/haskell/BUILD.md
@@ -24,6 +24,18 @@ After installing `stack`, make sure MSYS2 is updated with:
 
 3. `stack exec -- pacman -Syu` again
 
+Open Git Bash and execute the following commands:
+
+  *  git config --global core.autocrlf false
+  *  git config --global core.eol lf
+  
+These commands ensure that when the repo is pulled, there are no formatting issues with end-of-line characters. An issue with the build dependencies can appear if this step is skipped.
+
+Using `cd`, navigate to the folder you wish to download the Onyx repo to
+
+Finally, pull the repo using Git Bash (and **not** GitHub GUI) with the following command:
+  *  git clone https://github.com/mtolly/onyx.git
+
 ## macOS
 
   * Xcode dev tools

--- a/haskell/BUILD.md
+++ b/haskell/BUILD.md
@@ -26,15 +26,15 @@ After installing `stack`, make sure MSYS2 is updated with:
 
 Open Git Bash and execute the following commands:
 
-  *  git config --global core.autocrlf false
-  *  git config --global core.eol lf
+  *  `git config --global core.autocrlf false`
+  *  `git config --global core.eol lf`
   
 These commands ensure that when the repo is pulled, there are no formatting issues with end-of-line characters. An issue with the build dependencies can appear if this step is skipped.
 
 Using `cd`, navigate to the folder you wish to download the Onyx repo to
 
 Finally, pull the repo using Git Bash (and **not** GitHub GUI) with the following command:
-  *  git clone https://github.com/mtolly/onyx.git
+  *  `git clone https://github.com/mtolly/onyx.git`
 
 ## macOS
 

--- a/haskell/build-dependencies
+++ b/haskell/build-dependencies
@@ -6,6 +6,7 @@ cd dependencies
 # we can probably just `stack exec make` on all platforms, but this is fine
 case $(uname) in
   MINGW* )
+    export STACK_YAML=../stack-ghc-9.2.yaml
     stack exec make
     ;;
   * )

--- a/haskell/dependencies/Makefile
+++ b/haskell/dependencies/Makefile
@@ -24,13 +24,13 @@ opus:
 	# and if we don't set the version, then libsndfile won't use any external libs
 	cd libs/opus && echo 'PACKAGE_VERSION="1.3.1"' > package_version
 	cd libs/opus && ./autogen.sh
-	cd libs/opus && env PKG_CONFIG_PATH=$(current_dir)/root/lib/pkgconfig ./configure --prefix=$(current_dir)/root
+	cd libs/opus && env PKG_CONFIG_PATH=$(current_dir)/root/lib/pkgconfig LDFLAGS="-lssp" ./configure --prefix=$(current_dir)/root
 	cd libs/opus && make
 	cd libs/opus && make install
 
 flac:
 	cd libs/flac && ./autogen.sh
-	cd libs/flac && env PKG_CONFIG_PATH=$(current_dir)/root/lib/pkgconfig ./configure --prefix=$(current_dir)/root
+	cd libs/flac && env PKG_CONFIG_PATH=$(current_dir)/root/lib/pkgconfig LDFLAGS="-lssp" ./configure --prefix=$(current_dir)/root
 	cd libs/flac && make
 	cd libs/flac && make install
 


### PR DESCRIPTION
Added some extra instructions for Windows compilation, namely the addition of flags to prevent errors during the dependency compilations.

The BUILD.md is updated too to ensure the dependency repos are properly formatted.